### PR TITLE
Fix meta-altera-refdes reference so "oebb.sh config" runs without error

### DIFF
--- a/README
+++ b/README
@@ -5,14 +5,14 @@ This is the Angstrom Distribution v2014.12 release.
 
 To configure the scripts and download the build metadata, do:
 
-	$ MACHINE=beagleboard ./oebb.sh config beagleboard
+	$ MACHINE=cyclone5 ./oebb.sh config cyclone5
 
-You can change the 'beagleboard' in the commandline above into the machine you are targeting.
+You can change the 'cyclone5' in the commandline above into arria5 or arria10.
 
 To start a build of the kernel, source the environment file and do:
 
-	$ . environment-angstrom
-	$ MACHINE=beagleboard bitbake virtual/kernel
+	$ . environment-angstrom-v2014.12
+	$ MACHINE=cyclone5 bitbake virtual/kernel
 
 For an example workflow for dealing with kernels please read http://www.slimlogic.co.uk/2011/05/openembeddedangstrom-kernel-workflow/
 

--- a/sources/layers.txt
+++ b/sources/layers.txt
@@ -32,5 +32,5 @@ meta-photography,git://github.com/koenkooi/meta-photography.git,master,060028912
 meta-telephony,git://github.com/koenkooi/meta-telephony,master,65238f85305f3179491e5e4be8152ea35454ac84
 meta-qualcomm,http://git.linaro.org/people/nicolas.dechesne/meta-qualcomm.git,master,1c876ee4dc5cb66d26d960f5b58c958ada2452a1
 meta-altera,https://github.com/altera-opensource/meta-altera.git,angstrom-v2014.12-yocto1.7_a10,HEAD
-meta-altera-refdes,https://github.com/meta-altera-refdes,gsrd15.0.1,HEAD
+meta-altera-refdes,https://github.com/altera-opensource/meta-altera-refdes,gsrd-15.0.1,HEAD
 openembedded-core,git://github.com/openembedded/oe-core.git,dizzy,HEAD


### PR DESCRIPTION
Fixes build buster and updates README to indicate appropriate MACHINE values.
